### PR TITLE
ADD: pierwsza wersja pliku Dockerfile

### DIFF
--- a/mokki-build-server/Dockerfile
+++ b/mokki-build-server/Dockerfile
@@ -1,0 +1,10 @@
+FROM debian
+
+WORKDIR /home/dev
+
+RUN cd /home/dev
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends wget bzip2;
+RUN wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2 --no-check-certificate
+RUN tar xjf gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2
+RUN rm gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2


### PR DESCRIPTION
Wzorowane na podstawie https://shantamraj.wordpress.com/2017/12/03/setting-up-arm-toolchain-on-ubuntu/
W przyszłości taki obraz posłuży nam za warstwę izolacji, dlatego proponuję wprowadzić dockera. Dodatkowym atutem jest fakt, że pracując na Windowsie mogę testować zachowanie pod Debianem.